### PR TITLE
Fix dependency issue. Otherwise e2e does not work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "polars~=1.1.0",
+    "polars=1.5.0",
     "pyarrow",
     "numpy",
     "scikit-learn",


### PR DESCRIPTION
Hi @kamilest. I have modified the pyproject.toml so that it will have no dependency issues with the aces package. I opened up an issue if you are curious as to what the context is: [https://github.com/mmcdermott/MEDS-DEV/issues/32](https://github.com/mmcdermott/MEDS-DEV/issues/32)