### PR TITLE
Relax dependency floors and add explicit lower bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,15 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "polars~=1.27.0",
-    "pyarrow",
-    "numpy",
-    "scikit-learn",
-    "hydra-core",
-    "meds~=0.4.0",
-    "flexible_schema",
+    "polars>=0.20.8",
+    "pyarrow>=14.0.0",
+    "numpy>=1.24; python_version < '3.12'",
+    "numpy>=1.26; python_version >= '3.12'",
+    "scikit-learn>=1.2; python_version < '3.12'",
+    "scikit-learn>=1.3.1; python_version >= '3.12'",
+    "hydra-core>=1.3",
+    "meds>=0.4.0,<0.5",
+    "flexible_schema>=0.1,<0.2",
 ]
 
 [tool.setuptools_scm]
@@ -41,7 +43,7 @@ doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
 
 [project.optional-dependencies]
 dev = ["pre-commit<4"]
-tests = ["pytest", "pytest-cov"]
+tests = ["pytest>=7", "pytest-cov>=4"]
 
 [project.scripts]
 meds-evaluation-cli = "meds_evaluation.__main__:main"


### PR DESCRIPTION
Closes #30.

## Summary

Replaces the existing compatible-release pins (`polars~=1.27.0`, `meds~=0.4.0`) and the bare, unbounded `pyarrow`, `numpy`, `scikit-learn`, `hydra-core`, and `flexible_schema` entries with explicit `>=` lower bounds at the **oldest published version** that still passes the full test and doctest suite on Python 3.10 / 3.11 / 3.12.

```
polars>=0.20.8
pyarrow>=14.0.0
numpy>=1.24  (>=1.26 on Python 3.12 — no earlier wheels)
scikit-learn>=1.2  (>=1.3.1 on Python 3.12 — no earlier wheels)
hydra-core>=1.3  (1.2 fails on 3.11 due to the mutable-default dataclass error)
meds>=0.4.0,<0.5
flexible_schema>=0.1,<0.2
```

Also sets `pytest>=7` / `pytest-cov>=4` in the `tests` extra so `--resolution=lowest-direct` doesn't resolve to prehistoric pytest (2.0.0).

## Floor derivation

Floors were found empirically: for each dep, install `==X.Y` in a clean `uv venv`, run `pytest src/ tests/ --doctest-modules`, then step to the next-oldest working version. Notable findings:

- **polars**: versions `0.20.0`–`0.20.7` fail on the bundled sample parquet (`Decoding Boolean "Rle"-encoded optional parquet pages` was NotYetImplemented until 0.20.8).
- **pyarrow**: `<14.0.0` has no Python 3.12 wheels (older releases need `pkg_resources` at build time).
- **numpy**: `<1.26` has no Python 3.12 wheels (older numpy needs `distutils`, removed from 3.12).
- **scikit-learn**: `1.2.x` has no 3.12 wheels, and `1.3.0` fails to build from source; `1.3.1` is the first version with a 3.12 wheel.
- **hydra-core**: `1.2` fails on Python 3.11 because of `ValueError: mutable default ... for field override_dirname is not allowed`.
- **meds / flexible_schema**: `0.4.0` / `0.1` respectively — earlier majors don't expose the `LabelSchema` / `Optional` / `.align()` surface this package uses.

Upper bounds on `meds` and `flexible_schema` are kept narrow because both are pre-1.0 and breaking across minor bumps is expected.

## Verification

Ran both the lowest-direct and latest resolutions on Python 3.10, 3.11, and 3.12:

```
uv pip install -e '.[tests]' --resolution=lowest-direct
uv pip install -e '.[tests]'   # latest
pytest src/ tests/ --doctest-modules
```

All 6 tests + doctests pass in every combination.

## Follow-ups

- #31 will push the **upper** bounds up to the newest compatible release (raising the ceiling).
- A subsequent PR will migrate the project to `uv` for build/dev/CI following the [meds-torch-data uv template](https://github.com/mmcdermott/meds-torch-data/pull/58).

## Test plan

- [x] `pytest src/ tests/ --doctest-modules` passes on Python 3.10 / 3.11 / 3.12 at lowest-direct resolution
- [x] Same on latest resolution
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)