### PR TITLE
Raise dependency floors to modern versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "polars>=0.20.8",
-    "pyarrow>=14.0.0",
-    "numpy>=1.24; python_version < '3.12'",
-    "numpy>=1.26; python_version >= '3.12'",
-    "scikit-learn>=1.2; python_version < '3.12'",
-    "scikit-learn>=1.3.1; python_version >= '3.12'",
+    "polars>=1.0",
+    "pyarrow>=16.0",
+    "numpy>=1.26",
+    "scikit-learn>=1.4",
     "hydra-core>=1.3",
-    "meds>=0.4.0,<0.5",
-    "flexible_schema>=0.1,<0.2",
+    "meds>=0.4.1,<0.5",
+    "flexible_schema>=0.1.1,<0.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -310,15 +310,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "flexible-schema", specifier = ">=0.1,<0.2" },
+    { name = "flexible-schema", specifier = ">=0.1.1,<0.2" },
     { name = "hydra-core", specifier = ">=1.3" },
-    { name = "meds", specifier = ">=0.4.0,<0.5" },
-    { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.24" },
-    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26" },
-    { name = "polars", specifier = ">=0.20.8" },
-    { name = "pyarrow", specifier = ">=14.0.0" },
-    { name = "scikit-learn", marker = "python_full_version < '3.12'", specifier = ">=1.2" },
-    { name = "scikit-learn", marker = "python_full_version >= '3.12'", specifier = ">=1.3.1" },
+    { name = "meds", specifier = ">=0.4.1,<0.5" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "polars", specifier = ">=1.0" },
+    { name = "pyarrow", specifier = ">=16.0" },
+    { name = "scikit-learn", specifier = ">=1.4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Closes #31. Stacked on top of #33 (uv migration), which is stacked on #32 (floor relaxation). Merge #32 -> #33 -> this in order.

## Summary

After #32 widened the supported dependency window down to the oldest still-working versions, this PR raises the **floor** back up to modern baselines. The intent is to give downstream tools co-installing `meds-evaluation` a resolution that lands on modern stacks by default — without the env-marker branches needed to support ancient Pythons.

```
polars            >=0.20.8  ->  >=1.0
pyarrow           >=14.0.0  ->  >=16.0
numpy             >=1.24 / >=1.26 (marked)  ->  >=1.26 (single floor)
scikit-learn      >=1.2 / >=1.3.1 (marked)  ->  >=1.4 (single floor)
hydra-core        >=1.3           (unchanged)
meds              >=0.4.0,<0.5    ->  >=0.4.1,<0.5
flexible_schema   >=0.1,<0.2      ->  >=0.1.1,<0.2
```

## Why raise now

- `polars 1.x` is the stable line we actually ship against; downstream (MEDS-DEV, meds-torch-data) have been on `polars~=1.x` for a while.
- Dropping the numpy / scikit-learn env markers is a simplification win: `numpy>=1.26` and `scikit-learn>=1.4` both have wheels for all supported Python versions, so the marker split added in #32 is no longer needed.
- `meds` and `flexible_schema` just move to latest patch (0.4.1 / 0.1.1). Still `<0.5` / `<0.2` because both are pre-1.0 and minor bumps are expected to be breaking.

No code changes were required — all 6 tests + doctests pass at both `--resolution=lowest-direct` and the latest resolution on Python 3.10/3.11/3.12.

## Verification

```
uv lock                                    # regenerated
uv sync --locked --group dev               # installs clean on 3.11
uv run pytest src/ tests/ --doctest-modules
```

Plus `uv pip install -e . --resolution=lowest-direct` on fresh venvs for Python 3.10/3.11/3.12 — all green.

## Test plan

- [ ] CI (tests matrix on 3.10/3.11/3.12, code-quality PR, build) green on this branch
- [ ] Merge order respected: #32 -> #33 -> this

🤖 Generated with [Claude Code](https://claude.com/claude-code)