### PR TITLE
Handle probability-only binary predictions

### DIFF
--- a/src/meds_evaluation/evaluate.py
+++ b/src/meds_evaluation/evaluate.py
@@ -26,6 +26,15 @@ from meds_evaluation.utils import _resample
 #   detect which set of metrics to obtain based on the task and the contents of the model prediction dataframe
 
 
+def _get_optional_prediction_column(predictions: pl.DataFrame, column_name: str) -> pl.Series | None:
+    """Return a usable optional prediction column, if one is present."""
+    if column_name not in predictions.columns:
+        return None
+
+    column = predictions[column_name]
+    return None if column.is_null().all() else column
+
+
 def evaluate_binary_classification(
     predictions: pl.DataFrame, samples_per_subject=4, resampling_seed=0
 ) -> dict[str, dict[str, float | list[ArrayLike]]]:
@@ -51,8 +60,12 @@ def evaluate_binary_classification(
 
     true_values = predictions[PredictionSchema.boolean_value_name]
 
-    predicted_values = predictions[PredictionSchema.predicted_boolean_value_name]
-    predicted_probabilities = predictions[PredictionSchema.predicted_boolean_probability_name]
+    predicted_values = _get_optional_prediction_column(
+        predictions, PredictionSchema.predicted_boolean_value_name
+    )
+    predicted_probabilities = _get_optional_prediction_column(
+        predictions, PredictionSchema.predicted_boolean_probability_name
+    )
 
     resampled_predictions = _resample(
         predictions,
@@ -63,18 +76,12 @@ def evaluate_binary_classification(
 
     true_values_resampled = resampled_predictions[PredictionSchema.boolean_value_name]
 
-    predicted_values_resampled = resampled_predictions[PredictionSchema.predicted_boolean_value_name]
-    predicted_probabilities_resampled = resampled_predictions[
-        PredictionSchema.predicted_boolean_probability_name
-    ]
-
-    if predicted_values.is_null().all():
-        predicted_values = None
-        predicted_values_resampled = None
-
-    if predicted_probabilities.is_null().all():
-        predicted_probabilities = None
-        predicted_probabilities_resampled = None
+    predicted_values_resampled = _get_optional_prediction_column(
+        resampled_predictions, PredictionSchema.predicted_boolean_value_name
+    )
+    predicted_probabilities_resampled = _get_optional_prediction_column(
+        resampled_predictions, PredictionSchema.predicted_boolean_probability_name
+    )
 
     results = {
         "samples_equally_weighted": _get_binary_classification_metrics(

--- a/tests/test_binary_classification.py
+++ b/tests/test_binary_classification.py
@@ -119,6 +119,24 @@ def test_evaluate_binary_classification_small_null_values():
     assert evaluate_binary_classification(input) == expected_output
 
 
+def test_evaluate_binary_classification_without_predicted_values():
+    input = BINARY_CLASSIFICATION_SMALL.drop(PredictionSchema.predicted_boolean_value_name)
+
+    expected_output = {
+        weighting: pytest.approx(
+            {
+                "roc_auc_score": 1.0,
+                "average_precision_score": 1.0,
+                "calibration_error": 0.3333333333333333,
+                "brier_score": 0.22000000000000006,
+            }
+        )
+        for weighting in ("samples_equally_weighted", "subjects_equally_weighted")
+    }
+
+    assert evaluate_binary_classification(input) == expected_output
+
+
 def test_evaluate_binary_classification_small_null_probabilities():
     input = align_pl(
         pl.DataFrame(


### PR DESCRIPTION
## Summary

- Treat absent optional prediction columns the same as all-null columns.
- Allow `evaluate_binary_classification` to evaluate probability-only predictions.
- Add an end-to-end regression test covering probability-only input.

## Root cause

`PredictionSchema` permits either `predicted_boolean_value` or
`predicted_boolean_probability`, but `evaluate_binary_classification`
unconditionally accessed both columns before checking whether they were usable.

When `predicted_boolean_value` was omitted, schema alignment preserved that
absence and evaluation raised `ColumnNotFoundError`.

The fix introduces a helper that returns `None` when an optional prediction
column is absent or entirely null, allowing metric calculation to use whichever
prediction columns are available.

## Validation

- Full test suite: 7 passed
- All pre-commit hooks passed

Fixes #35
